### PR TITLE
Fix CoFH/Feedback#265

### DIFF
--- a/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockTank.java
@@ -104,6 +104,9 @@ public class ItemBlockTank extends ItemBlockTEBase implements IFluidContainerIte
 	@Override
 	public FluidStack getFluid(ItemStack container) {
 
+		if (!container.hasTagCompound()) {
+			return null;
+		}
 		if (!container.getTagCompound().hasKey("Fluid")) {
 			return null;
 		}
@@ -121,6 +124,9 @@ public class ItemBlockTank extends ItemBlockTEBase implements IFluidContainerIte
 
 		if (resource == null || container.getCount() > 1 || isCreative(container)) {
 			return 0;
+		}
+		if (!container.hasTagCompound()) {
+			setDefaultTag(container);
 		}
 		int capacity = getCapacity(container);
 
@@ -171,6 +177,9 @@ public class ItemBlockTank extends ItemBlockTEBase implements IFluidContainerIte
 	@Override
 	public FluidStack drain(ItemStack container, int maxDrain, boolean doDrain) {
 
+		if (!container.hasTagCompound()) {
+			return null;
+		}
 		if (!container.getTagCompound().hasKey("Fluid") || maxDrain == 0 || container.getCount() > 1) {
 			return null;
 		}

--- a/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockTank.java
@@ -125,9 +125,6 @@ public class ItemBlockTank extends ItemBlockTEBase implements IFluidContainerIte
 		if (resource == null || container.getCount() > 1 || isCreative(container)) {
 			return 0;
 		}
-		if (!container.hasTagCompound()) {
-			setDefaultTag(container);
-		}
 		int capacity = getCapacity(container);
 
 		if (!doFill) {


### PR DESCRIPTION
A few methods assumed that the item stack already had an NBTTagCompound set, this adds checks to return quickly if that assumption is false. This approach current won't work for the drain method if setDefaultTag sets a fluid.

Committed on github manually, please compile and test this BEFORE merging.