### PR TITLE
[1.12.2] Fix NPE in satchel

### DIFF
--- a/src/main/java/cofh/thermalexpansion/item/ItemSatchel.java
+++ b/src/main/java/cofh/thermalexpansion/item/ItemSatchel.java
@@ -127,7 +127,7 @@ public class ItemSatchel extends ItemMulti implements IInitializer, IMultiModeIt
 	@Override
 	public void onUpdate(ItemStack stack, World world, Entity entity, int itemSlot, boolean isSelected) {
 
-		if (isVoid(stack) && stack.getTagCompound().hasKey("Random")) {
+		if (isVoid(stack) && stack.getTagCompound() != null && stack.getTagCompound().hasKey("Random")) {
 			stack.getTagCompound().removeTag("Random");
 		}
 	}


### PR DESCRIPTION
Fix for Internal Server Error with stacktrace:
```
net.minecraft.util.ReportedException: Ticking player
        at net.minecraft.entity.player.EntityPlayerMP.func_71127_g(EntityPlayerMP.java:459) ~[oq.class:?]
        at net.minecraft.network.NetHandlerPlayServer.func_73660_a(NetHandlerPlayServer.java:173) ~[pa.class:?]
        at net.minecraftforge.fml.common.network.handshake.NetworkDispatcher$1.func_73660_a(NetworkDispatcher.java:209) ~[NetworkDispatcher$1.class:?]
        at net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:285) ~[gw.class:?]
        at net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:180) [oz.class:?]
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:788) [MinecraftServer.class:?]
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:396) [nz.class:?]
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:666) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:524) [MinecraftServer.class:?]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_152]
Caused by: java.lang.NullPointerException
        at cofh.thermalexpansion.item.ItemSatchel.func_77663_a(ItemSatchel.java:130) ~[ItemSatchel.class:?]
        at net.minecraft.item.ItemStack.func_77945_a(ItemStack.java:526) ~[aip.class:?]
        at net.minecraft.entity.player.InventoryPlayer.func_70429_k(InventoryPlayer.java:363) ~[aec.class:?]
        at net.minecraft.entity.player.EntityPlayer.func_70636_d(EntityPlayer.java:511) ~[aed.class:?]
        at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:2167) ~[vp.class:?]
        at net.minecraft.entity.player.EntityPlayer.func_70071_h_(EntityPlayer.java:234) ~[aed.class:?]
        at net.minecraft.entity.player.EntityPlayerMP.func_71127_g(EntityPlayerMP.java:382) ~[oq.class:?]
        ... 9 more
```