### PR TITLE
Fixed compatibility with SecretRoomsMod

### DIFF
--- a/src/main/java/cofh/thermalexpansion/block/device/BlockDevice.java
+++ b/src/main/java/cofh/thermalexpansion/block/device/BlockDevice.java
@@ -214,6 +214,12 @@ public class BlockDevice extends BlockTEBase implements IModelRegister, IBakeryP
 	@SideOnly (Side.CLIENT)
 	public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
 
+		TileEntity tile = world.getTileEntity(pos);
+		
+		if (!(tile instanceof TileDeviceBase)) {
+			return state;
+		}
+		
 		return ModelBakery.handleExtendedState((IExtendedBlockState) super.getExtendedState(state, world, pos), world, pos);
 	}
 

--- a/src/main/java/cofh/thermalexpansion/block/dynamo/BlockDynamo.java
+++ b/src/main/java/cofh/thermalexpansion/block/dynamo/BlockDynamo.java
@@ -268,6 +268,12 @@ public class BlockDynamo extends BlockTEBase implements IModelRegister, IBakeryP
 	@SideOnly (Side.CLIENT)
 	public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
 
+		TileEntity tile = world.getTileEntity(pos);
+		
+		if (!(tile instanceof TileDynamoBase)) {
+			return state;
+		}
+		
 		return ModelBakery.handleExtendedState((IExtendedBlockState) super.getExtendedState(state, world, pos), world, pos);
 	}
 

--- a/src/main/java/cofh/thermalexpansion/block/machine/BlockMachine.java
+++ b/src/main/java/cofh/thermalexpansion/block/machine/BlockMachine.java
@@ -246,6 +246,12 @@ public class BlockMachine extends BlockTEBase implements IModelRegister, IBakery
 	@SideOnly (Side.CLIENT)
 	public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
 
+		TileEntity tile = world.getTileEntity(pos);
+		
+		if (!(tile instanceof TileMachineBase)) {
+			return state;
+		}
+		
 		return ModelBakery.handleExtendedState((IExtendedBlockState) super.getExtendedState(state, world, pos), world, pos);
 	}
 

--- a/src/main/java/cofh/thermalexpansion/block/storage/BlockCache.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/BlockCache.java
@@ -282,6 +282,12 @@ public class BlockCache extends BlockTEBase implements IModelRegister, IBakeryPr
 	@SideOnly (Side.CLIENT)
 	public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
 
+		TileEntity tile = world.getTileEntity(pos);
+		
+		if (!(tile instanceof TileCache)) {
+			return state;
+		}
+		
 		return ModelBakery.handleExtendedState((IExtendedBlockState) super.getExtendedState(state, world, pos), world, pos);
 	}
 

--- a/src/main/java/cofh/thermalexpansion/block/storage/BlockCell.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/BlockCell.java
@@ -172,6 +172,12 @@ public class BlockCell extends BlockTEBase implements IModelRegister, IBakeryPro
 	@SideOnly (Side.CLIENT)
 	public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
 
+		TileEntity tile = world.getTileEntity(pos);
+		
+		if (!(tile instanceof TileCell)) {
+			return state;
+		}
+		
 		return ModelBakery.handleExtendedState((IExtendedBlockState) super.getExtendedState(state, world, pos), world, pos);
 	}
 

--- a/src/main/java/cofh/thermalexpansion/block/storage/BlockTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/BlockTank.java
@@ -220,6 +220,12 @@ public class BlockTank extends BlockTEBase implements IModelRegister, IBakeryPro
 	@SideOnly (Side.CLIENT)
 	public IBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
 
+		TileEntity tile = world.getTileEntity(pos);
+		
+		if (!(tile instanceof TileTank)) {
+			return state;
+		}
+		
 		return ModelBakery.handleExtendedState((IExtendedBlockState) super.getExtendedState(state, world, pos), world, pos);
 	}
 


### PR DESCRIPTION
There was some compatibility issues with SecretRoomsMod which caused the game to crash. This should solve it. If you dont want this, adding:

```
public boolean canBlockBeMirrored(World world, IBlockState state, BlockPos pos) {
		return false;
	}
```
to the block classes will also do the trick