### PR TITLE
SmelterManager recipe removal issues with ModTweaker (TE 5.5.1.33+)

### DIFF
--- a/src/main/java/cofh/thermalexpansion/util/managers/machine/SmelterManager.java
+++ b/src/main/java/cofh/thermalexpansion/util/managers/machine/SmelterManager.java
@@ -358,8 +358,32 @@ public class SmelterManager {
 
 	/* REMOVE RECIPES */
 	public static SmelterRecipe removeRecipe(ItemStack primaryInput, ItemStack secondaryInput) {
+		if (primaryInput.isEmpty() || secondaryInput.isEmpty()) {
+			return null;
+		}
+		ComparableItemStackValidated query = convertInput(primaryInput);
+		ComparableItemStackValidated querySecondary = convertInput(secondaryInput);
 
-		return recipeMap.remove(asList(convertInput(primaryInput), convertInput(secondaryInput)));
+		SmelterRecipe recipe = recipeMap.remove(asList(query, querySecondary));
+
+		if (recipe == null) {
+			recipe = recipeMap.remove(asList(querySecondary, query));
+		}
+		if (recipe == null) {
+			if (isItemFlux(primaryInput)) {
+				querySecondary.metadata = OreDictionary.WILDCARD_VALUE;
+			} else {
+				query.metadata = OreDictionary.WILDCARD_VALUE;
+			}
+			recipe = recipeMap.remove(asList(query, querySecondary));
+			if (recipe == null) {
+				recipe = recipeMap.remove(asList(querySecondary, query));
+			}
+		}
+		if (recipe == null) {
+			return null;
+		}
+		return recipe;
 	}
 
 	/* HELPERS */


### PR DESCRIPTION
I'm not sure that this pull request is the correct way to resolve the issue. The code duplication feels horrendously redundant, but as far as I can tell it does seem to fix it.  Hopefully there is a better way of fixing it. 

See [#1320](https://github.com/CoFH/Feedback/issues/1320) for details.