### PR TITLE
Fix higher holding levels on Tanks/Caches/Cells

### DIFF
--- a/src/main/java/cofh/thermalexpansion/block/storage/BlockCache.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/BlockCache.java
@@ -139,7 +139,7 @@ public class BlockCache extends BlockTEBase implements IModelRegister, IBakeryPr
 			TileCache tile = (TileCache) world.getTileEntity(pos);
 
 			tile.isCreative = (stack.getTagCompound().getBoolean("Creative"));
-			tile.enchantHolding = (byte) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, CoreEnchantments.holding.getMaxLevel());
+			tile.enchantHolding = (short) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, Short.MAX_VALUE);
 			tile.setLevel(stack.getTagCompound().getByte("Level"));
 
 			if (stack.getTagCompound().hasKey("Item")) {

--- a/src/main/java/cofh/thermalexpansion/block/storage/BlockCell.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/BlockCell.java
@@ -99,7 +99,7 @@ public class BlockCell extends BlockTEBase implements IModelRegister, IBakeryPro
 			TileCell tile = (TileCell) world.getTileEntity(pos);
 
 			tile.isCreative = (stack.getTagCompound().getBoolean("Creative"));
-			tile.enchantHolding = (byte) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, CoreEnchantments.holding.getMaxLevel());
+			tile.enchantHolding = (short) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, Short.MAX_VALUE);
 			tile.setLevel(stack.getTagCompound().getByte("Level"));
 			tile.amountRecv = stack.getTagCompound().getInteger("Recv");
 			tile.amountSend = stack.getTagCompound().getInteger("Send");

--- a/src/main/java/cofh/thermalexpansion/block/storage/BlockTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/BlockTank.java
@@ -105,7 +105,7 @@ public class BlockTank extends BlockTEBase implements IModelRegister, IBakeryPro
 			TileTank tile = (TileTank) world.getTileEntity(pos);
 
 			tile.isCreative = (stack.getTagCompound().getBoolean("Creative"));
-			tile.enchantHolding = (short) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, Byte.MAX_VALUE);
+			tile.enchantHolding = (short) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, Short.MAX_VALUE);
 			tile.setLevel(stack.getTagCompound().getByte("Level"));
 
 			if (stack.getTagCompound().hasKey(CoreProps.FLUID)) {

--- a/src/main/java/cofh/thermalexpansion/block/storage/BlockTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/BlockTank.java
@@ -105,7 +105,7 @@ public class BlockTank extends BlockTEBase implements IModelRegister, IBakeryPro
 			TileTank tile = (TileTank) world.getTileEntity(pos);
 
 			tile.isCreative = (stack.getTagCompound().getBoolean("Creative"));
-			tile.enchantHolding = (byte) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, CoreEnchantments.holding.getMaxLevel());
+			tile.enchantHolding = (short) MathHelper.clamp(EnchantmentHelper.getEnchantmentLevel(CoreEnchantments.holding, stack), 0, Byte.MAX_VALUE);
 			tile.setLevel(stack.getTagCompound().getByte("Level"));
 
 			if (stack.getTagCompound().hasKey(CoreProps.FLUID)) {

--- a/src/main/java/cofh/thermalexpansion/block/storage/TileCache.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/TileCache.java
@@ -78,7 +78,7 @@ public class TileCache extends TileAugmentableSecure implements IReconfigurableF
 
 	byte facing = 3;
 
-	public byte enchantHolding;
+	public short enchantHolding;
 	boolean lock = false;
 
 	private CacheItemHandler handler;
@@ -175,7 +175,7 @@ public class TileCache extends TileAugmentableSecure implements IReconfigurableF
 	/* COMMON METHODS */
 	public static int getMaxCapacity(int level, int enchant) {
 
-		return CAPACITY[MathHelper.clamp(level, 0, 4)] + (CAPACITY[MathHelper.clamp(level, 0, 4)] * enchant) / 2;
+		return (int) Math.max(CAPACITY[MathHelper.clamp(level, 0, 4)] + (CAPACITY[MathHelper.clamp(level, 0, 4)] * (double) enchant) / 2, 0);
 	}
 
 	public CacheItemHandler getHandler() {
@@ -273,7 +273,7 @@ public class TileCache extends TileAugmentableSecure implements IReconfigurableF
 	@Override
 	public void readFromNBT(NBTTagCompound nbt) {
 
-		enchantHolding = nbt.getByte("EncHolding");
+		enchantHolding = nbt.getShort("EncHolding");
 
 		super.readFromNBT(nbt);
 
@@ -287,7 +287,7 @@ public class TileCache extends TileAugmentableSecure implements IReconfigurableF
 
 		super.writeToNBT(nbt);
 
-		nbt.setByte("EncHolding", enchantHolding);
+		nbt.setShort("EncHolding", enchantHolding);
 		nbt.setByte(CoreProps.FACING, facing);
 		handler.writeToNBT(nbt);
 		return nbt;
@@ -331,7 +331,7 @@ public class TileCache extends TileAugmentableSecure implements IReconfigurableF
 
 		PacketBase payload = super.getTilePacket();
 
-		payload.addByte(enchantHolding);
+		payload.addShort(enchantHolding);
 		payload.addByte(facing);
 		payload.addBool(lock);
 		payload.addItemStack(ItemHelper.cloneStack(getStoredInstance()));
@@ -356,7 +356,7 @@ public class TileCache extends TileAugmentableSecure implements IReconfigurableF
 
 		super.handleTilePacket(payload);
 
-		enchantHolding = payload.getByte();
+		enchantHolding = payload.getShort();
 		facing = payload.getByte();
 		lock = payload.getBool();
 		handler.setItem(payload.getItemStack(), payload.getInt());

--- a/src/main/java/cofh/thermalexpansion/block/storage/TileCell.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/TileCell.java
@@ -90,7 +90,7 @@ public class TileCell extends TilePowered implements ITickable, IEnergyProvider 
 	private int meterTracker;
 	private int outputTracker;
 
-	public byte enchantHolding;
+	public short enchantHolding;
 	public int amountRecv;
 	public int amountSend;
 
@@ -252,7 +252,7 @@ public class TileCell extends TilePowered implements ITickable, IEnergyProvider 
 	/* COMMON METHODS */
 	public static int getMaxCapacity(int level, int enchant) {
 
-		return CAPACITY[MathHelper.clamp(level, 0, 4)] + (CAPACITY[MathHelper.clamp(level, 0, 4)] * enchant) / 2;
+		return (int) Math.max(CAPACITY[MathHelper.clamp(level, 0, 4)] + (CAPACITY[MathHelper.clamp(level, 0, 4)] * (double) enchant) / 2, 0);
 	}
 
 	public int getScaledEnergyStored(int scale) {
@@ -316,7 +316,7 @@ public class TileCell extends TilePowered implements ITickable, IEnergyProvider 
 	@Override
 	public void readFromNBT(NBTTagCompound nbt) {
 
-		enchantHolding = nbt.getByte("EncHolding");
+		enchantHolding = nbt.getShort("EncHolding");
 
 		super.readFromNBT(nbt);
 
@@ -333,7 +333,7 @@ public class TileCell extends TilePowered implements ITickable, IEnergyProvider 
 
 		super.writeToNBT(nbt);
 
-		nbt.setByte("EncHolding", enchantHolding);
+		nbt.setShort("EncHolding", enchantHolding);
 		nbt.setInteger(CoreProps.TRACK_OUT, outputTracker);
 		nbt.setInteger("Recv", amountRecv);
 		nbt.setInteger("Send", amountSend);
@@ -380,7 +380,7 @@ public class TileCell extends TilePowered implements ITickable, IEnergyProvider 
 
 		PacketBase payload = super.getTilePacket();
 
-		payload.addByte(enchantHolding);
+		payload.addShort(enchantHolding);
 		payload.addInt(amountRecv);
 		payload.addInt(amountSend);
 
@@ -402,7 +402,7 @@ public class TileCell extends TilePowered implements ITickable, IEnergyProvider 
 
 		super.handleTilePacket(payload);
 
-		enchantHolding = payload.getByte();
+		enchantHolding = payload.getShort();
 		amountRecv = payload.getInt();
 		amountSend = payload.getInt();
 

--- a/src/main/java/cofh/thermalexpansion/block/storage/TileTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/TileTank.java
@@ -77,7 +77,7 @@ public class TileTank extends TileAugmentableSecure implements ITickable, ITileI
 	private int compareTracker;
 	private int lastDisplayLevel;
 
-	public byte enchantHolding;
+	public short enchantHolding;
 
 	boolean lock = false;
 	boolean renderFlag = true;
@@ -246,7 +246,7 @@ public class TileTank extends TileAugmentableSecure implements ITickable, ITileI
 	/* COMMON METHODS */
 	public static int getMaxCapacity(int level, int enchant) {
 
-		return CAPACITY[MathHelper.clamp(level, 0, 4)] + (CAPACITY[MathHelper.clamp(level, 0, 4)] * enchant) / 2;
+		return (int) Math.max(CAPACITY[MathHelper.clamp(level, 0, 4)] + (CAPACITY[MathHelper.clamp(level, 0, 4)] * (double) enchant) / 2, 0);
 	}
 
 	protected void transferFluid() {
@@ -356,7 +356,7 @@ public class TileTank extends TileAugmentableSecure implements ITickable, ITileI
 	@Override
 	public void readFromNBT(NBTTagCompound nbt) {
 
-		enchantHolding = nbt.getByte("EncHolding");
+		enchantHolding = nbt.getShort("EncHolding");
 
 		super.readFromNBT(nbt);
 
@@ -369,7 +369,7 @@ public class TileTank extends TileAugmentableSecure implements ITickable, ITileI
 
 		super.writeToNBT(nbt);
 
-		nbt.setByte("EncHolding", enchantHolding);
+		nbt.setShort("EncHolding", enchantHolding);
 		tank.writeToNBT(nbt);
 		return nbt;
 	}
@@ -413,7 +413,7 @@ public class TileTank extends TileAugmentableSecure implements ITickable, ITileI
 
 		PacketBase payload = super.getTilePacket();
 
-		payload.addByte(enchantHolding);
+		payload.addShort(enchantHolding);
 		payload.addBool(lock);
 		payload.addFluidStack(tank.getFluid());
 
@@ -436,7 +436,7 @@ public class TileTank extends TileAugmentableSecure implements ITickable, ITileI
 
 		super.handleTilePacket(payload);
 
-		enchantHolding = payload.getByte();
+		enchantHolding = payload.getShort();
 		lock = payload.getBool();
 		tank.setFluid(payload.getFluidStack());
 


### PR DESCRIPTION
Changes serialization type into short (increasing effective cap from 127 -> 32767) and properly clamps the values of the tank in TileTank#getMaxCapacity.