### PR TITLE
gtcx, gtc, ic2c compat

### DIFF
--- a/src/main/java/cofh/thermalexpansion/init/TEPlugins.java
+++ b/src/main/java/cofh/thermalexpansion/init/TEPlugins.java
@@ -46,6 +46,8 @@ public class TEPlugins {
 		pluginExtraAlchemy = new PluginExtraAlchemy();
 		pluginExU2 = new PluginExU2();
 		pluginFamiliarFauna = new PluginFamiliarFauna();
+		pluginGTC = new PluginGTC();
+		pluginGTCX = new PluginGTCX();
 		pluginIC2 = new PluginIC2();
 		pluginIceAndFire = new PluginIceAndFire();
 		pluginImmersiveEngineering = new PluginImmersiveEngineering();
@@ -94,6 +96,8 @@ public class TEPlugins {
 		initList.add(pluginExtraAlchemy);
 		initList.add(pluginExU2);
 		initList.add(pluginFamiliarFauna);
+		initList.add(pluginGTC);
+		initList.add(pluginGTCX);
 		initList.add(pluginIC2);
 		initList.add(pluginIceAndFire);
 		initList.add(pluginImmersiveEngineering);
@@ -157,6 +161,8 @@ public class TEPlugins {
 	private static PluginExtraAlchemy pluginExtraAlchemy;
 	private static PluginExU2 pluginExU2;
 	private static PluginFamiliarFauna pluginFamiliarFauna;
+	private static PluginGTC pluginGTC;
+	private static PluginGTCX pluginGTCX;
 	private static PluginIC2 pluginIC2;
 	private static PluginIceAndFire pluginIceAndFire;
 	private static PluginImmersiveEngineering pluginImmersiveEngineering;

--- a/src/main/java/cofh/thermalexpansion/item/ItemSatchel.java
+++ b/src/main/java/cofh/thermalexpansion/item/ItemSatchel.java
@@ -315,7 +315,7 @@ public class ItemSatchel extends ItemMulti implements IInitializer, IColorableIt
 					ItemStack slot = inv.getStackInSlot(i);
 					if (slot.isEmpty()) {
 						inv.setInventorySlotContents(i, eventItem.copy());
-						eventItem.setCount(0);
+						eventItem.setCount(Math.max(eventItem.getCount() - inv.getInventoryStackLimit(),0));
 					} else if (ItemHandlerHelper.canItemStacksStack(eventItem, slot)) {
 						int fill = slot.getMaxStackSize() - slot.getCount();
 						if (fill > eventItem.getCount()) {

--- a/src/main/java/cofh/thermalexpansion/plugins/PluginGTC.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/PluginGTC.java
@@ -1,0 +1,43 @@
+package cofh.thermalexpansion.plugins;
+
+import cofh.core.util.helpers.ItemHelper;
+import cofh.thermalexpansion.util.managers.machine.CentrifugeManager;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Loader;
+
+import java.util.Collections;
+
+import static java.util.Arrays.asList;
+
+public class PluginGTC extends PluginTEBase {
+
+    public static final String MOD_ID = "gtclassic";
+    public static final String MOD_NAME = "Gregtech Classic";
+
+    public PluginGTC() {
+
+        super(MOD_ID, MOD_NAME);
+    }
+
+    @Override
+    public void initializeDelegate() {
+        /* CENTRIFUGE */
+        {
+            int energy = CentrifugeManager.DEFAULT_ENERGY;
+
+            CentrifugeManager.addRecipe(energy * 50, new ItemStack(Blocks.DIRT, 64, 0), asList(new ItemStack(Blocks.SAND, 32, 0), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 351), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 350), new ItemStack(Items.CLAY_BALL, 2)), null);
+            CentrifugeManager.addRecipe(energy * 50, new ItemStack(Blocks.GRASS, 64, 0), asList(new ItemStack(Blocks.SAND, 32, 0), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 351), getItemStack(PluginIC2.MOD_ID,"itemmisc", 4, 350), new ItemStack(Items.CLAY_BALL, 2)), null);
+            CentrifugeManager.addRecipe(energy * 62, new ItemStack(Blocks.MYCELIUM, 64, 0), asList(new ItemStack(Blocks.SAND, 32, 0), new ItemStack(Blocks.BROWN_MUSHROOM, 16), new ItemStack(Blocks.RED_MUSHROOM, 16), new ItemStack(Items.CLAY_BALL, 8)), null);
+            CentrifugeManager.addRecipe(energy * 35, ItemHelper.getOre("dustEnderEye", 16), asList(ItemHelper.getOre("dustEnderpearl", 8), new ItemStack(Items.BLAZE_POWDER, 8)), null);
+            CentrifugeManager.addRecipe(energy * 125, new ItemStack(Items.DYE, 64, 4), asList(ItemHelper.getOre("dustLazurite", 48), ItemHelper.getOre("dustSodalite", 8), ItemHelper.getOre("dustPyrite", 4), ItemHelper.getOre("dustCalcite", 4)), null);
+            CentrifugeManager.addRecipe((int)(energy * 12.5F), getItemStack(PluginIC2.MOD_ID, "itemharz", 8, 0), asList(getItemStack(PluginIC2.MOD_ID,"itemmisc", 28, 450), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 351), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 350)), null);
+            CentrifugeManager.addRecipe(energy * 24, new ItemStack(Blocks.STONE, 4, 1), asList(ItemHelper.getOre("dustAluminium", 2), ItemHelper.getOre("dustFlint", 1), ItemHelper.getOre("dustClay")), null);
+            CentrifugeManager.addRecipe(energy * 36, new ItemStack(Blocks.STONE, 16, 3), Collections.singletonList(ItemHelper.getOre("dustNickel", 2)), null);
+            if (!Loader.isModLoaded(PluginGTCX.MOD_ID) && !Loader.isModLoaded(PluginTechReborn.MOD_ID))
+            CentrifugeManager.addRecipe(energy * 24, ItemHelper.getOre("dustBasalt", 16), asList(ItemHelper.getOre("dustFlint", 8), ItemHelper.getOre("dustCalcite", 3), ItemHelper.getOre("dustCarbon", 1), ItemHelper.getOre("dustEmerald")), null);
+        }
+    }
+
+}

--- a/src/main/java/cofh/thermalexpansion/plugins/PluginGTC.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/PluginGTC.java
@@ -30,11 +30,11 @@ public class PluginGTC extends PluginTEBase {
             CentrifugeManager.addRecipe(energy * 50, new ItemStack(Blocks.DIRT, 64, 0), asList(new ItemStack(Blocks.SAND, 32, 0), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 351), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 350), new ItemStack(Items.CLAY_BALL, 2)), null);
             CentrifugeManager.addRecipe(energy * 50, new ItemStack(Blocks.GRASS, 64, 0), asList(new ItemStack(Blocks.SAND, 32, 0), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 351), getItemStack(PluginIC2.MOD_ID,"itemmisc", 4, 350), new ItemStack(Items.CLAY_BALL, 2)), null);
             CentrifugeManager.addRecipe(energy * 62, new ItemStack(Blocks.MYCELIUM, 64, 0), asList(new ItemStack(Blocks.SAND, 32, 0), new ItemStack(Blocks.BROWN_MUSHROOM, 16), new ItemStack(Blocks.RED_MUSHROOM, 16), new ItemStack(Items.CLAY_BALL, 8)), null);
-            CentrifugeManager.addRecipe(energy * 35, ItemHelper.getOre("dustEnderEye", 16), asList(ItemHelper.getOre("dustEnderpearl", 8), new ItemStack(Items.BLAZE_POWDER, 8)), null);
+            CentrifugeManager.addRecipe(energy * 35, ItemHelper.getOre("dustEnderEye", 16), asList(ItemHelper.getOre("dustEnderPearl", 8), new ItemStack(Items.BLAZE_POWDER, 8)), null);
             CentrifugeManager.addRecipe(energy * 125, new ItemStack(Items.DYE, 64, 4), asList(ItemHelper.getOre("dustLazurite", 48), ItemHelper.getOre("dustSodalite", 8), ItemHelper.getOre("dustPyrite", 4), ItemHelper.getOre("dustCalcite", 4)), null);
             CentrifugeManager.addRecipe((int)(energy * 12.5F), getItemStack(PluginIC2.MOD_ID, "itemharz", 8, 0), asList(getItemStack(PluginIC2.MOD_ID,"itemmisc", 28, 450), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 351), getItemStack(PluginIC2.MOD_ID,"itemmisc", 2, 350)), null);
             CentrifugeManager.addRecipe(energy * 24, new ItemStack(Blocks.STONE, 4, 1), asList(ItemHelper.getOre("dustAluminium", 2), ItemHelper.getOre("dustFlint", 1), ItemHelper.getOre("dustClay")), null);
-            CentrifugeManager.addRecipe(energy * 36, new ItemStack(Blocks.STONE, 16, 3), Collections.singletonList(ItemHelper.getOre("dustNickel", 2)), null);
+            CentrifugeManager.addRecipe(energy * 36, new ItemStack(Blocks.STONE, 16, 3), Collections.singletonList(ItemHelper.getOre("dustNickel")), null);
             if (!Loader.isModLoaded(PluginGTCX.MOD_ID) && !Loader.isModLoaded(PluginTechReborn.MOD_ID))
             CentrifugeManager.addRecipe(energy * 24, ItemHelper.getOre("dustBasalt", 16), asList(ItemHelper.getOre("dustFlint", 8), ItemHelper.getOre("dustCalcite", 3), ItemHelper.getOre("dustCarbon", 1), ItemHelper.getOre("dustEmerald")), null);
         }

--- a/src/main/java/cofh/thermalexpansion/plugins/PluginGTCX.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/PluginGTCX.java
@@ -1,0 +1,56 @@
+package cofh.thermalexpansion.plugins;
+
+import cofh.core.util.helpers.ItemHelper;
+import cofh.thermalexpansion.util.managers.machine.CentrifugeManager;
+import cofh.thermalexpansion.util.managers.machine.TransposerManager;
+import cofh.thermalfoundation.init.TFFluids;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Loader;
+
+import java.util.Collections;
+
+import static java.util.Arrays.asList;
+
+public class PluginGTCX extends PluginTEBase {
+
+    public static final String MOD_ID = "gtc_expansion";
+    public static final String MOD_NAME = "Gregtech Classic Expansion";
+
+    public PluginGTCX() {
+
+        super(MOD_ID, MOD_NAME);
+    }
+
+    @Override
+    public void initializeDelegate() {
+
+        /* TRANSPOSER */
+        {
+            int energy = 2000;
+            if (!Loader.isModLoaded(PluginTechReborn.MOD_ID))
+                TransposerManager.addFillRecipe(energy, ItemHelper.getOre("ingotHotTungstensteel"), ItemHelper.getOre("ingotTungstensteel"), new FluidStack(TFFluids.fluidCryotheum, 200), false);
+            TransposerManager.addFillRecipe(energy, ItemHelper.getOre("ingotHotTungsten"), ItemHelper.getOre("ingotTungsten"), new FluidStack(TFFluids.fluidCryotheum, 200), false);
+            TransposerManager.addFillRecipe(energy, ItemHelper.getOre("ingotHotIridium"), ItemHelper.getOre("ingotIridium"), new FluidStack(TFFluids.fluidCryotheum, 200), false);
+            TransposerManager.addFillRecipe(energy, ItemHelper.getOre("ingotHotKanthal"), ItemHelper.getOre("ingotKanthal"), new FluidStack(TFFluids.fluidCryotheum, 200), false);
+            TransposerManager.addFillRecipe(energy, ItemHelper.getOre("ingotHotOsmium"), ItemHelper.getOre("ingotOsmium"), new FluidStack(TFFluids.fluidCryotheum, 200), false);
+        }
+
+        /* CENTRIFUGE */
+        {
+            int energy = CentrifugeManager.DEFAULT_ENERGY;
+
+            if (!Loader.isModLoaded(PluginTechReborn.MOD_ID)){
+                CentrifugeManager.addRecipe(energy * 15, ItemHelper.getOre("dustRedGarnet", 16), asList(ItemHelper.getOre("dustSpessartine", 8), ItemHelper.getOre("dustAlmandine", 5), ItemHelper.getOre("dustPyrope", 3)), null);
+                CentrifugeManager.addRecipe(energy * 15, ItemHelper.getOre("dustYellowGarnet", 16), asList(ItemHelper.getOre("dustGrossular", 8), ItemHelper.getOre("dustAndradite", 5), ItemHelper.getOre("dustUvarovite", 3)), null);
+                CentrifugeManager.addRecipe((int)(energy * 1.2F), ItemHelper.getOre("dustDarkAshes", 2), asList(ItemHelper.getOre("dustAshes"), ItemHelper.getOre("dustSlag")), null);
+                CentrifugeManager.addRecipe((int)(energy * 5.3F), ItemHelper.getOre("dustMarble", 8), asList(ItemHelper.getOre("dustCalcite", 7), ItemHelper.getOre("dustMagnesium")), null);
+                CentrifugeManager.addRecipe(energy * 24, ItemHelper.getOre("dustBasalt", 16), asList(ItemHelper.getOre("dustFlint", 8), ItemHelper.getOre("dustDarkAshes", 4), ItemHelper.getOre("dustCalcite", 3), ItemHelper.getOre("dustOlivine")), null);
+            }
+            CentrifugeManager.addRecipe(energy * 2, ItemHelper.getOre("dustRedrock", 16), asList(ItemHelper.getOre("dustCalcite", 8), ItemHelper.getOre("dustFlint", 4), ItemHelper.getOre("dustClay", 4)), null);
+            CentrifugeManager.addRecipe((int)(energy * 1.2F), ItemHelper.getOre("dustAshes", 2), Collections.singletonList(ItemHelper.getOre("dustCarbon")), null);
+            CentrifugeManager.addRecipe(energy * 4, ItemHelper.getOre("dustSlag", 16), asList(ItemHelper.getOre("dustSulfur", 4), ItemHelper.getOre("dustPhosphorus", 4), new ItemStack(Items.IRON_NUGGET, 3), new ItemStack(Items.GOLD_NUGGET)), null);
+        }
+    }
+}

--- a/src/main/java/cofh/thermalexpansion/plugins/PluginIC2.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/PluginIC2.java
@@ -10,10 +10,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Loader;
 
 public class PluginIC2 extends PluginTEBase {
 
 	public static final String MOD_ID = "ic2";
+	public static final String MOD_ID_CLASSIC = "ic2-classic-spmod";
 	public static final String MOD_NAME = "IndustrialCraft 2";
 
 	public PluginIC2() {
@@ -35,17 +37,21 @@ public class PluginIC2 extends PluginTEBase {
 
 		/* INSOLATOR */
 		{
-			ItemStack logRubber = getItemStack("rubber_wood", 1, 0);
-			ItemStack saplingRubber = getItemStack("sapling", 1, 0);
+			String name = Loader.isModLoaded(MOD_ID_CLASSIC) ? "blockrubwood" : "rubber_wood";
+			ItemStack logRubber = getItemStack(name, 1, 0);
+			name = Loader.isModLoaded(MOD_ID_CLASSIC) ? "blockrubsapling" : "sapling";
+			ItemStack saplingRubber = getItemStack(name, 1, 0);
 
 			InsolatorManager.addDefaultTreeRecipe(saplingRubber, ItemHelper.cloneStack(logRubber, 6), saplingRubber);
 		}
 
 		/* COMPACTOR */
 		{
-			ItemStack coalBall = getItemStack("crafting", 1, 16);
-			ItemStack coalBallCompressed = getItemStack("crafting", 1, 17);
-			ItemStack coalChunk = getItemStack("crafting", 1, 18);
+			String name = Loader.isModLoaded(MOD_ID_CLASSIC) ? "itemmisc" : "crafting";
+			int metaBase  = Loader.isModLoaded(MOD_ID_CLASSIC) ? 250 : 16;
+			ItemStack coalBall = getItemStack(name, 1, metaBase);
+			ItemStack coalBallCompressed = getItemStack(name, 1, metaBase + 1);
+			ItemStack coalChunk = getItemStack(name, 1, metaBase + 2);
 
 			int energy = CompactorManager.DEFAULT_ENERGY;
 


### PR DESCRIPTION
I think I got everything, I'm just not sure whether I should disable the shared centrifuge recipes between tr and gtcx on tr's side or gtcx's side. currently I have it such that if tr is loaded the corresponding gtcx recipes are  not loaded.