### PR TITLE
Fix Transposer FluidHandler shenanigans

### DIFF
--- a/src/main/java/cofh/thermalexpansion/block/machine/TileTransposer.java
+++ b/src/main/java/cofh/thermalexpansion/block/machine/TileTransposer.java
@@ -297,8 +297,8 @@ public class TileTransposer extends TileMachineBase {
 			return false;
 		}
 		if (!hasFluidHandler && FluidHelper.isFluidHandler(inventory[0])) {
-			if (!extractMode && TransposerManager.fillRecipeExists(inventory[0], tank.getFluid())) {
-				// There is a specific recipe for this! Do not use FluidHandler stuff.
+			if (!extractMode && (tank.getFluidAmount() <= 0 || TransposerManager.fillRecipeExists(inventory[0], tank.getFluid()))) {
+				// There is (or might be) a specific recipe for this! Do not use FluidHandler stuff.
 			} else if (extractMode && TransposerManager.extractRecipeExists(inventory[0])) {
 				// There is a specific recipe for this! Do not use FluidHandler stuff.
 			} else {


### PR DESCRIPTION
Currently, the Transposer will enter its mode of filling a FluidHandler if its tank is empty. This causes an issue as when a fluid is input that would result in a valid recipe, the Transposer will try to fill it as a FluidHandler, instead of trying to process the recipe. I noticed this when trying to automate the production of potions in a modpack with EnderCore installed, which turns Glass Bottles into FluidHandlers.

This could probably also be fixed by checking in updateHandler() if the current item/fluid combo makes a valid recipe, and sort of jumping over to the other mod. It'd make the Transposer more flexible, but that could end up getting complicated and ugly. A third option could be to add an option to the GUI to switch between only Transposer recipes, only filling FluidHandlers, or both, sort of like EnderIO's Alloy Smelter does with vanilla smelting recipes. But that'd be way more changes than I'm comfortable with making before getting someone else's opinion. It would be cool though.