### PR TITLE
Fixed Insolator handling of custom recipes (+added config option)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,10 @@ dependencies {
 	deobfCompile "cofh:RedstoneFlux:${config.rf_mc_version}-${config.rf_version}:universal"
     deobfCompile "cofh:CoFHCore:${config.mc_version}-${config.cofh_core_version}:universal"
     deobfCompile "cofh:ThermalFoundation:${config.mc_version}-${config.tf_version}:universal"
+	deobfCompile "cofh:CoFHWorld:${config.mc_version}-${config.cofh_world_version}:universal"
 
     deobfCompile "codechicken:CodeChickenLib:${config.ccl_mc_version}-${config.ccl_version}:universal"
-	compile "mezz.jei:jei_${config.jei_mc_version}:${config.jei_version}"
+	//compile "mezz.jei:jei_${config.jei_mc_version}:${config.jei_version}"
 }
 
 //Pull the mod version from code.

--- a/build.properties
+++ b/build.properties
@@ -7,6 +7,7 @@ mappings=snapshot_20171003
 rf_mc_version=1.12
 rf_version=2.1.0.+
 cofh_core_version=4.6.0.+
+cofh_world_version=1.3.1.+
 tf_version=2.6.0.+
 
 ccl_mc_version=1.12.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 04 07:35:31 ACST 2017
+#Mon Jan 13 01:06:43 EST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The Phytogenic Insolator with Monoculture Cycle upgrade does not preserve "non-fertilizer" inputs in recipes without fertilizer.  Normally this is not an observable problem as there are no recipes without fertilizer.  However, it can arise for custom recipes.  For example, FTB Interactions  significantly changes the recipe to the Monoculture Cycle, clearly with the intention of allowing it to make custom recipes much cheaper, but it does not affect these recipes.  This pull request makes it so the Monoculture Cycle upgrade preserves the second input in the case that neither is a fertilizer, and adds a config option to disable this behavior.

I tested that the insulator has its normal behavior under these changes.  I did not actually test the handling of custom recipes is now correct though so I'm only 95% sure.

Only the changes to `TileInsolator.java` should be added, I had issues with duplicate jei / no cofh world so I had to change the gradle config a bit.