### PR TITLE
Allow for creative block disassembly without OP.

### DIFF
--- a/src/main/java/cofh/thermalexpansion/block/BlockTEBase.java
+++ b/src/main/java/cofh/thermalexpansion/block/BlockTEBase.java
@@ -11,6 +11,7 @@ import cofh.core.util.helpers.ItemHelper;
 import cofh.core.util.helpers.ServerHelper;
 import cofh.core.util.helpers.WrenchHelper;
 import cofh.thermalexpansion.ThermalExpansion;
+import cofh.thermalexpansion.init.TEProps;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -183,7 +184,7 @@ public abstract class BlockTEBase extends BlockCoreTile implements IConfigGui {
 
 		TileNameable tile = (TileNameable) world.getTileEntity(pos);
 
-		if (tile instanceof TileAugmentableSecure && ((TileAugmentableSecure) tile).isCreative && !CoreUtils.isOp(player)) {
+		if (tile instanceof TileAugmentableSecure && (!TEProps.allowNonOPDisassembly && ((TileAugmentableSecure) tile).isCreative && !CoreUtils.isOp(player))) {
 			return false;
 		}
 		return super.canDismantle(world, pos, state, player);

--- a/src/main/java/cofh/thermalexpansion/init/TEProps.java
+++ b/src/main/java/cofh/thermalexpansion/init/TEProps.java
@@ -62,6 +62,11 @@ public class TEProps {
 
 		comment = "This sets the minimum upgradeable block tier for Redstone Control functionality.";
 		levelRedstoneControl = ThermalExpansion.CONFIG.getConfiguration().getInt("LevelRedstoneControl", category, levelRedstoneControl, CoreProps.LEVEL_MIN, CoreProps.LEVEL_MAX, comment);
+
+		category = "Device";
+
+		comment = "If TRUE, Creative versions of Blocks can be disassembled without server operator permissions.";
+		allowNonOPDisassembly = ThermalExpansion.CONFIG.getConfiguration().getBoolean("AllowNonOPDisassembly", category, allowNonOPDisassembly, comment);
 	}
 
 	private static void configClient() {
@@ -276,6 +281,8 @@ public class TEProps {
 	public static boolean creativeTabHideMorbs = false;
 
 	public static boolean enableSounds = true;
+
+	public static boolean allowNonOPDisassembly = false;
 
 	/* UPGRADE */
 	public static int levelAutoInput = 0;


### PR DESCRIPTION
This would be done through a config option, and be disabled by default.

This would be useful in modpacks that give players access to creative items, which they would otherwise need to ask a server operator to remove.