### PR TITLE
[I18n] Fix hardcoded semicolon

### DIFF
--- a/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockCache.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockCache.java
@@ -60,9 +60,9 @@ public class ItemBlockCache extends ItemBlockTEBase implements IInventoryContain
 		tooltip.add(StringHelper.getInfoText("info.thermalexpansion.storage.cache"));
 
 		if (isCreative(stack)) {
-			tooltip.add(StringHelper.localize("info.cofh.capacity") + ": " + StringHelper.localize("info.cofh.infinite"));
+			tooltip.add(StringHelper.localize("info.cofh.capacity") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.localize("info.cofh.infinite"));
 		} else {
-			tooltip.add(StringHelper.localize("info.cofh.capacity") + ": " + StringHelper.formatNumber(getSizeInventory(stack)));
+			tooltip.add(StringHelper.localize("info.cofh.capacity") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(getSizeInventory(stack)));
 		}
 		if (stack.getTagCompound().hasKey("Item")) {
 			ItemStack stored = ItemHelper.readItemStackFromNBT(stack.getTagCompound().getCompoundTag("Item"));

--- a/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockCell.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockCell.java
@@ -79,9 +79,9 @@ public class ItemBlockCell extends ItemBlockTEBase implements IEnergyContainerIt
 		if (isCreative(stack)) {
 			tooltip.add(StringHelper.localize("info.cofh.charge") + ": 1.21G RF");
 		} else {
-			tooltip.add(StringHelper.localize("info.cofh.charge") + ": " + StringHelper.getScaledNumber(getEnergyStored(stack)) + " / " + StringHelper.getScaledNumber(getMaxEnergyStored(stack)) + " RF");
+			tooltip.add(StringHelper.localize("info.cofh.charge") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.getScaledNumber(getEnergyStored(stack)) + " / " + StringHelper.getScaledNumber(getMaxEnergyStored(stack)) + " RF");
 		}
-		tooltip.add(StringHelper.localize("info.cofh.send") + "/" + StringHelper.localize("info.cofh.receive") + ": " + StringHelper.formatNumber(stack.getTagCompound().getInteger("Send")) + "/" + StringHelper.formatNumber(stack.getTagCompound().getInteger("Recv")) + " RF/t");
+		tooltip.add(StringHelper.localize("info.cofh.send") + "/" + StringHelper.localize("info.cofh.receive") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(stack.getTagCompound().getInteger("Send")) + "/" + StringHelper.formatNumber(stack.getTagCompound().getInteger("Recv")) + " RF/t");
 
 		RedstoneControlHelper.addRSControlInformation(stack, tooltip);
 	}

--- a/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/ItemBlockTank.java
@@ -67,11 +67,11 @@ public class ItemBlockTank extends ItemBlockTEBase implements IFluidContainerIte
 		FluidStack fluid = getFluid(stack);
 		if (fluid != null) {
 			String color = fluid.getFluid().getRarity().rarityColor.toString();
-			tooltip.add(StringHelper.localize("info.cofh.fluid") + ": " + color + fluid.getFluid().getLocalizedName(fluid) + StringHelper.LIGHT_GRAY);
+			tooltip.add(StringHelper.localize("info.cofh.fluid") + StringHelper.localize("info.thermalexpansion.semicolon") + color + fluid.getFluid().getLocalizedName(fluid) + StringHelper.LIGHT_GRAY);
 			if (isCreative(stack)) {
 				tooltip.add(StringHelper.localize("info.cofh.infiniteSource"));
 			} else {
-				tooltip.add(StringHelper.localize("info.cofh.level") + ": " + StringHelper.formatNumber(fluid.amount) + " / " + StringHelper.formatNumber(getCapacity(stack)) + " mB");
+				tooltip.add(StringHelper.localize("info.cofh.level") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(fluid.amount) + " / " + StringHelper.formatNumber(getCapacity(stack)) + " mB");
 			}
 			if (isLocked(stack)) {
 				tooltip.add(StringHelper.YELLOW + StringHelper.localize("info.cofh.locked"));
@@ -79,7 +79,7 @@ public class ItemBlockTank extends ItemBlockTEBase implements IFluidContainerIte
 				tooltip.add(StringHelper.YELLOW + StringHelper.localize("info.cofh.unlocked"));
 			}
 		} else {
-			tooltip.add(StringHelper.localize("info.cofh.fluid") + ": " + StringHelper.localize("info.cofh.empty"));
+			tooltip.add(StringHelper.localize("info.cofh.fluid") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.localize("info.cofh.empty"));
 
 			if (isCreative(stack)) {
 				tooltip.add(StringHelper.localize("info.cofh.infiniteSource"));

--- a/src/main/java/cofh/thermalexpansion/block/storage/TileCache.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/TileCache.java
@@ -431,11 +431,11 @@ public class TileCache extends TileAugmentableSecure implements IReconfigurableF
 			return;
 		}
 		if (!getStoredInstance().isEmpty()) {
-			info.add(new TextComponentTranslation("info.cofh.item").appendText(": " + StringHelper.getItemName(getStoredInstance())));
-			info.add(new TextComponentTranslation("info.cofh.amount").appendText(": " + StringHelper.formatNumber(getStoredCount()) + "/" + StringHelper.formatNumber(handler.capacity)));
+			info.add(new TextComponentTranslation("info.cofh.item").appendText(StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.getItemName(getStoredInstance())));
+			info.add(new TextComponentTranslation("info.cofh.amount").appendText(StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(getStoredCount()) + "/" + StringHelper.formatNumber(handler.capacity)));
 			info.add(new TextComponentTranslation(lock ? "info.cofh.locked" : "info.cofh.unlocked"));
 		} else {
-			info.add(new TextComponentTranslation("info.cofh.item").appendText(": ").appendSibling(new TextComponentTranslation("info.cofh.empty")));
+			info.add(new TextComponentTranslation("info.cofh.item").appendText(StringHelper.localize("info.thermalexpansion.semicolon")).appendSibling(new TextComponentTranslation("info.cofh.empty")));
 		}
 	}
 

--- a/src/main/java/cofh/thermalexpansion/block/storage/TileTank.java
+++ b/src/main/java/cofh/thermalexpansion/block/storage/TileTank.java
@@ -451,11 +451,11 @@ public class TileTank extends TileAugmentableSecure implements ITickable, ITileI
 			return;
 		}
 		if (tank.getFluid() != null) {
-			info.add(new TextComponentTranslation("info.cofh.fluid").appendText(": " + StringHelper.getFluidName(tank.getFluid())));
-			info.add(new TextComponentTranslation("info.cofh.amount").appendText(": " + StringHelper.formatNumber(tank.getFluidAmount()) + "/" + StringHelper.formatNumber(tank.getCapacity()) + " mB"));
+			info.add(new TextComponentTranslation("info.cofh.fluid").appendText(StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.getFluidName(tank.getFluid())));
+			info.add(new TextComponentTranslation("info.cofh.amount").appendText(StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(tank.getFluidAmount()) + "/" + StringHelper.formatNumber(tank.getCapacity()) + " mB"));
 			info.add(new TextComponentTranslation(lock ? "info.cofh.locked" : "info.cofh.unlocked"));
 		} else {
-			info.add(new TextComponentTranslation("info.cofh.fluid").appendText(": ").appendSibling(new TextComponentTranslation("info.cofh.empty")));
+			info.add(new TextComponentTranslation("info.cofh.fluid").appendText(StringHelper.localize("info.thermalexpansion.semicolon")).appendSibling(new TextComponentTranslation("info.cofh.empty")));
 		}
 	}
 

--- a/src/main/java/cofh/thermalexpansion/gui/client/device/GuiFluidBuffer.java
+++ b/src/main/java/cofh/thermalexpansion/gui/client/device/GuiFluidBuffer.java
@@ -132,7 +132,7 @@ public class GuiFluidBuffer extends GuiDeviceBase {
 			if (myTile.locks[i]) {
 				FluidStack fluid = myTile.getTank(i).getFluid();
 				String color = fluid.getFluid().getRarity().rarityColor.toString();
-				lock[i].setToolTip(StringHelper.localize("info.cofh.locked") + ": " + color + StringHelper.localize(fluid.getFluid().getLocalizedName(fluid)) + StringHelper.END);
+				lock[i].setToolTip(StringHelper.localize("info.cofh.locked") + StringHelper.localize("info.thermalexpansion.semicolon") + color + StringHelper.localize(fluid.getFluid().getLocalizedName(fluid)) + StringHelper.END);
 				lock[i].setSheetX(176);
 				lock[i].setHoverX(176);
 			} else {

--- a/src/main/java/cofh/thermalexpansion/gui/client/dynamo/GuiDynamoBase.java
+++ b/src/main/java/cofh/thermalexpansion/gui/client/dynamo/GuiDynamoBase.java
@@ -108,7 +108,7 @@ public abstract class GuiDynamoBase extends GuiContainerCore {
 		}
 		int energy = baseTile.getFuelEnergy(event.getItemStack());
 		if (energy > 0) {
-			event.getToolTip().add(StringHelper.BRIGHT_GREEN + StringHelper.localize("info.cofh.energy") + ": " + StringHelper.getScaledNumber(energy) + " RF" + StringHelper.END);
+			event.getToolTip().add(StringHelper.BRIGHT_GREEN + StringHelper.localize("info.cofh.energy") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.getScaledNumber(energy) + " RF" + StringHelper.END);
 		}
 	}
 

--- a/src/main/java/cofh/thermalexpansion/gui/client/storage/GuiTank.java
+++ b/src/main/java/cofh/thermalexpansion/gui/client/storage/GuiTank.java
@@ -103,7 +103,7 @@ public class GuiTank extends GuiContainerCore {
 		if (baseTile.isLocked()) {
 			FluidStack fluid = baseTile.getTankFluid();
 			String color = fluid.getFluid().getRarity().rarityColor.toString();
-			lock.setToolTip(StringHelper.localize("info.cofh.locked") + ": " + color + StringHelper.localize(fluid.getFluid().getLocalizedName(fluid)) + StringHelper.END);
+			lock.setToolTip(StringHelper.localize("info.cofh.locked") + StringHelper.localize("info.thermalexpansion.semicolon") + color + StringHelper.localize(fluid.getFluid().getLocalizedName(fluid)) + StringHelper.END);
 			lock.setSheetX(176);
 			lock.setHoverX(176);
 		} else {

--- a/src/main/java/cofh/thermalexpansion/item/ItemAugment.java
+++ b/src/main/java/cofh/thermalexpansion/item/ItemAugment.java
@@ -52,7 +52,7 @@ public class ItemAugment extends ItemMulti implements IInitializer, IAugmentItem
 	@Override
 	public String getItemStackDisplayName(ItemStack stack) {
 
-		return StringHelper.localize("info.thermalexpansion.augment.0") + ": " + super.getItemStackDisplayName(stack);
+		return StringHelper.localize("info.thermalexpansion.augment.0") + StringHelper.localize("info.thermalexpansion.semicolon") + super.getItemStackDisplayName(stack);
 	}
 
 	@Override

--- a/src/main/java/cofh/thermalexpansion/item/ItemCapacitor.java
+++ b/src/main/java/cofh/thermalexpansion/item/ItemCapacitor.java
@@ -82,10 +82,10 @@ public class ItemCapacitor extends ItemMultiRF implements IInitializer, IBauble 
 
 		if (isCreative(stack)) {
 			tooltip.add(StringHelper.localize("info.cofh.charge") + ": 1.21G RF");
-			tooltip.add(StringHelper.localize("info.cofh.send") + ": " + StringHelper.formatNumber(getSend(stack)) + " RF/t");
+			tooltip.add(StringHelper.localize("info.cofh.send") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(getSend(stack)) + " RF/t");
 		} else {
-			tooltip.add(StringHelper.localize("info.cofh.charge") + ": " + StringHelper.getScaledNumber(getEnergyStored(stack)) + " / " + StringHelper.getScaledNumber(getMaxEnergyStored(stack)) + " RF");
-			tooltip.add(StringHelper.localize("info.cofh.send") + "/" + StringHelper.localize("info.cofh.receive") + ": " + StringHelper.formatNumber(getSend(stack)) + "/" + StringHelper.formatNumber(getReceive(stack)) + " RF/t");
+			tooltip.add(StringHelper.localize("info.cofh.charge") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.getScaledNumber(getEnergyStored(stack)) + " / " + StringHelper.getScaledNumber(getMaxEnergyStored(stack)) + " RF");
+			tooltip.add(StringHelper.localize("info.cofh.send") + "/" + StringHelper.localize("info.cofh.receive") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(getSend(stack)) + "/" + StringHelper.formatNumber(getReceive(stack)) + " RF/t");
 		}
 	}
 

--- a/src/main/java/cofh/thermalexpansion/item/ItemReservoir.java
+++ b/src/main/java/cofh/thermalexpansion/item/ItemReservoir.java
@@ -102,14 +102,14 @@ public class ItemReservoir extends ItemMulti implements IInitializer, IBauble, I
 		FluidStack fluid = getFluid(stack);
 		if (fluid != null) {
 			String color = fluid.getFluid().getRarity().rarityColor.toString();
-			tooltip.add(StringHelper.localize("info.cofh.fluid") + ": " + color + fluid.getFluid().getLocalizedName(fluid) + StringHelper.LIGHT_GRAY);
+			tooltip.add(StringHelper.localize("info.cofh.fluid") + StringHelper.localize("info.thermalexpansion.semicolon") + color + fluid.getFluid().getLocalizedName(fluid) + StringHelper.LIGHT_GRAY);
 			if (isCreative(stack)) {
 				tooltip.add(StringHelper.localize("info.cofh.infiniteSource"));
 			} else {
-				tooltip.add(StringHelper.localize("info.cofh.level") + ": " + StringHelper.formatNumber(fluid.amount) + " / " + StringHelper.formatNumber(getCapacity(stack)) + " mB");
+				tooltip.add(StringHelper.localize("info.cofh.level") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(fluid.amount) + " / " + StringHelper.formatNumber(getCapacity(stack)) + " mB");
 			}
 		} else {
-			tooltip.add(StringHelper.localize("info.cofh.fluid") + ": " + StringHelper.localize("info.cofh.empty"));
+			tooltip.add(StringHelper.localize("info.cofh.fluid") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.localize("info.cofh.empty"));
 
 			if (isCreative(stack)) {
 				tooltip.add(StringHelper.localize("info.cofh.infiniteSource"));

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/device/coolant/CoolantWrapper.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/device/coolant/CoolantWrapper.java
@@ -66,7 +66,7 @@ public class CoolantWrapper extends BaseFuelWrapper {
 		//		List<String> tooltip = new ArrayList<>();
 		//
 		//		if (mouseX > 71 && mouseX < 84 && mouseY > 7 && mouseY < 48) {
-		//			tooltip.add(StringHelper.localize("info.cofh.energy") + ": " + StringHelper.formatNumber(energy) + " TC");
+		//			tooltip.add(StringHelper.localize("info.cofh.energy") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(energy) + " TC");
 		//		}
 		//		return tooltip;
 	}

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/dynamo/BaseFuelWrapper.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/dynamo/BaseFuelWrapper.java
@@ -32,7 +32,7 @@ public abstract class BaseFuelWrapper extends BlankRecipeWrapper {
 		List<String> tooltip = new ArrayList<>();
 
 		if (mouseX > 71 && mouseX < 84 && mouseY > 7 && mouseY < 48) {
-			tooltip.add(StringHelper.localize("info.cofh.energy") + ": " + StringHelper.formatNumber(energy) + " RF");
+			tooltip.add(StringHelper.localize("info.cofh.energy") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(energy) + " RF");
 		}
 		return tooltip;
 	}

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/BaseRecipeWrapper.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/BaseRecipeWrapper.java
@@ -26,7 +26,7 @@ public abstract class BaseRecipeWrapper extends BlankRecipeWrapper {
 		List<String> tooltip = new ArrayList<>();
 
 		if (energyMeter != null && mouseX > 2 && mouseX < 15 && mouseY > 8 && mouseY < 49) {
-			tooltip.add(StringHelper.localize("info.cofh.energy") + ": " + StringHelper.formatNumber(energy) + " RF");
+			tooltip.add(StringHelper.localize("info.cofh.energy") + StringHelper.localize("info.thermalexpansion.semicolon") + StringHelper.formatNumber(energy) + " RF");
 		}
 		return tooltip;
 	}

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/centrifuge/CentrifugeRecipeCategory.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/centrifuge/CentrifugeRecipeCategory.java
@@ -138,7 +138,7 @@ public class CentrifugeRecipeCategory extends BaseRecipeCategory<CentrifugeRecip
 
 			if (!recipeWrapper.chance.isEmpty() && slotIndex >= 1 && slotIndex <= 4) {
 				if (recipeWrapper.chance.get(slotIndex - 1) < 100) {
-					tooltip.add(StringHelper.localize("info.cofh.chance") + ": " + recipeWrapper.chance.get(slotIndex - 1) + "%");
+					tooltip.add(StringHelper.localize("info.cofh.chance") + StringHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance.get(slotIndex - 1) + "%");
 				}
 			}
 		});

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/centrifuge/CentrifugeRecipeCategoryMobs.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/centrifuge/CentrifugeRecipeCategoryMobs.java
@@ -89,7 +89,7 @@ public class CentrifugeRecipeCategoryMobs extends CentrifugeRecipeCategory {
 					if (recipeWrapper.outputs.get(slotIndex - 1).getCount() > 1) {
 						tooltip.add(StringHelper.localize("gui.thermalexpansion.jei.centrifuge.mobNotice"));
 					}
-					tooltip.add(StringHelper.localize("gui.thermalexpansion.jei.centrifuge.mobChance") + ": " + recipeWrapper.chance.get(slotIndex - 1) + "%");
+					tooltip.add(StringHelper.localize("gui.thermalexpansion.jei.centrifuge.mobChance") + StringHelper.localize("info.thermalexpansion.semicolon")ngHelper.localize("info.thermalexpansion.semicolon")ngHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance.get(slotIndex - 1) + "%");
 				}
 			}
 		});

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/insolator/InsolatorRecipeCategory.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/insolator/InsolatorRecipeCategory.java
@@ -140,7 +140,7 @@ public class InsolatorRecipeCategory extends BaseRecipeCategory<InsolatorRecipeW
 			guiItemStacks.addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
 
 				if (slotIndex == 3) {
-					tooltip.add(StringHelper.localize("info.cofh.chance") + ": " + recipeWrapper.chance + "%");
+					tooltip.add(StringHelper.localize("info.cofh.chance") + StringHelper.localize("info.thermalexpansion.semicolon")ngHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance + "%");
 				}
 			});
 		}

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/pulverizer/PulverizerRecipeCategory.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/pulverizer/PulverizerRecipeCategory.java
@@ -121,7 +121,7 @@ public class PulverizerRecipeCategory extends BaseRecipeCategory<PulverizerRecip
 			guiItemStacks.addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
 
 				if (slotIndex == 2) {
-					tooltip.add(StringHelper.localize("info.cofh.chance") + ": " + recipeWrapper.chance + "%");
+					tooltip.add(StringHelper.localize("info.cofh.chance") + StringHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance + "%");
 				}
 			});
 		}

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/refinery/RefineryRecipeCategory.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/refinery/RefineryRecipeCategory.java
@@ -139,7 +139,7 @@ public class RefineryRecipeCategory extends BaseRecipeCategory<RefineryRecipeWra
 		guiItemStacks.addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
 
 			if (slotIndex == 0 && recipeWrapper.chance < 100) {
-				tooltip.add(StringHelper.localize("info.cofh.chance") + ": " + recipeWrapper.chance + "%");
+				tooltip.add(StringHelper.localize("info.cofh.chance") + StringHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance + "%");
 			}
 		});
 

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/sawmill/SawmillRecipeCategory.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/sawmill/SawmillRecipeCategory.java
@@ -121,7 +121,7 @@ public class SawmillRecipeCategory extends BaseRecipeCategory<SawmillRecipeWrapp
 			guiItemStacks.addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
 
 				if (slotIndex == 2) {
-					tooltip.add(StringHelper.localize("info.cofh.chance") + ": " + recipeWrapper.chance + "%");
+					tooltip.add(StringHelper.localize("info.cofh.chance") + StringHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance + "%");
 				}
 			});
 		}

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/smelter/SmelterRecipeCategory.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/smelter/SmelterRecipeCategory.java
@@ -123,7 +123,7 @@ public class SmelterRecipeCategory extends BaseRecipeCategory<SmelterRecipeWrapp
 			guiItemStacks.addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
 
 				if (slotIndex == 3) {
-					tooltip.add(StringHelper.localize("info.cofh.chance") + ": " + recipeWrapper.chance + "%");
+					tooltip.add(StringHelper.localize("info.cofh.chance") + StringHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance + "%");
 				}
 			});
 		}

--- a/src/main/java/cofh/thermalexpansion/plugins/jei/machine/transposer/TransposerRecipeCategoryExtract.java
+++ b/src/main/java/cofh/thermalexpansion/plugins/jei/machine/transposer/TransposerRecipeCategoryExtract.java
@@ -153,7 +153,7 @@ public class TransposerRecipeCategoryExtract extends TransposerRecipeCategory {
 		guiItemStacks.addTooltipCallback((slotIndex, input, ingredient, tooltip) -> {
 
 			if (slotIndex == 1 && recipeWrapper.chance < 100) {
-				tooltip.add(StringHelper.localize("info.cofh.chance") + ": " + recipeWrapper.chance + "%");
+				tooltip.add(StringHelper.localize("info.cofh.chance") + StringHelper.localize("info.thermalexpansion.semicolon") + recipeWrapper.chance + "%");
 			}
 		});
 

--- a/src/main/resources/assets/thermalexpansion/lang/cs_CZ.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/cs_CZ.lang
@@ -1,5 +1,7 @@
 #cs_CZ
 
+info.thermalexpansion.semicolon=: 
+
 achievement.thermalexpansion.florb.desc=Obsahuje tekutinu. Můžeš to hodit.
 achievement.thermalexpansion.florb=Mohu to hodit ?!
 achievement.thermalexpansion.florbMagmatic.desc=Florb. Ano, uchovává lávu. Ty příšero.

--- a/src/main/resources/assets/thermalexpansion/lang/de_DE.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/de_DE.lang
@@ -46,7 +46,7 @@ gui.thermalexpansion.storage.cell.maxRecv=Max Input
 gui.thermalexpansion.storage.cell.maxSend=Max Output
 
 info.thermalexpansion.augment.0=Verbesserung
-
+info.thermalexpansion.semicolon=: 
 
 
 

--- a/src/main/resources/assets/thermalexpansion/lang/en_GB.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/en_GB.lang
@@ -7,6 +7,8 @@ info.thermalexpansion.augment.machineFurnaceFood=Redstone Furnace: Specialisatio
 
 info.thermalexpansion.light.1=Can be almost any colour you wish.
 
+info.thermalexpansion.semicolon=: 
+
 tab.thermalexpansion.light.1=Colour and mode may be adjusted with sliders.
 
 tile.thermalexpansion.machine.pulverizer.name=Pulveriser

--- a/src/main/resources/assets/thermalexpansion/lang/en_PT.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/en_PT.lang
@@ -35,6 +35,7 @@ info.thermalexpansion.multimeter=Use a multimetarr whilst skulking to configure.
 info.thermalexpansion.wrench=Wrench whilst skulking to dismantle.
 
 #Items
+info.thermalexpansion.semicolon=: 
 item.thermalexpansion.augment.dynamoEfficiency0.name=Extra Widgetbox
 item.thermalexpansion.augment.dynamoEfficiency1.name=Better Flux Linkage
 item.thermalexpansion.augment.dynamoEfficiency2.name=CryoCoil Regulatorr

--- a/src/main/resources/assets/thermalexpansion/lang/en_US.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/en_US.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=Increase RF Input by
 gui.thermalexpansion.storage.cell.incSend=Increase RF Output by
 
 info.thermalexpansion.augment.0=Augment
+info.thermalexpansion.semicolon=: 
 
 info.thermalexpansion.augment.dynamoBoiler.0=Dynamos: Output Specialization
 info.thermalexpansion.augment.dynamoBoiler.a.0=Converts an applicable Dynamo into a Steam Boiler.

--- a/src/main/resources/assets/thermalexpansion/lang/es_ES.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/es_ES.lang
@@ -11,6 +11,8 @@ info.thermalexpansion.augment.dynamoThrottle.0=Activa la salida minima del dynam
 
 info.thermalexpansion.augment.machineFurnaceFood.0=Incrementa la salida de Comida.
 
+info.thermalexpansion.semicolon=: 
+
 info.thermalexpansion.dynamo.compression=Require cobustibles en estado liquido y refrigerantes liquidos.
 info.thermalexpansion.dynamo.enervation=Extrae el flux de objetos varios.
 info.thermalexpansion.dynamo.magmatic=Require fluidos calientes.

--- a/src/main/resources/assets/thermalexpansion/lang/fr_FR.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/fr_FR.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=Augmenter entrée RF par
 gui.thermalexpansion.storage.cell.incSend=Augmenter sortie RF par
 
 info.thermalexpansion.augment.0=Amélioration 
+info.thermalexpansion.semicolon=: 
 
 info.thermalexpansion.augment.dynamoBoiler.0=Dynamos : spécialisation de sortie
 info.thermalexpansion.augment.dynamoBoiler.a.0=Convertit une dynamo compatible en une chaudière à vapeur.

--- a/src/main/resources/assets/thermalexpansion/lang/it_IT.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/it_IT.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=Aumenta l'Entrata di RF di
 gui.thermalexpansion.storage.cell.incSend=Aumenta l'Uscita di RF di
 
 info.thermalexpansion.augment.0=Aumentamento
+info.thermalexpansion.semicolon=: 
 
 info.thermalexpansion.augment.dynamoBoiler.0=Dinamo: Output Specializzazione di Uscita
 info.thermalexpansion.augment.dynamoBoiler.a.0=Converte un Dinamo applicabile in una Caldaia a Vapore.

--- a/src/main/resources/assets/thermalexpansion/lang/ja_JP.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/ja_JP.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=RF流入量を増やす：
 gui.thermalexpansion.storage.cell.incSend=RF流出量を増やす：
 
 info.thermalexpansion.augment.0=オーグメント
+info.thermalexpansion.semicolon=：
 
 info.thermalexpansion.augment.dynamoBoiler.0=発電機：出力特化
 info.thermalexpansion.augment.dynamoBoiler.a.0=発電機を蒸気ボイラーにします。

--- a/src/main/resources/assets/thermalexpansion/lang/ko_KR.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/ko_KR.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=RF 입력 감소
 gui.thermalexpansion.storage.cell.incSend=RF 출력 감소
 
 info.thermalexpansion.augment.0=늘리기
+info.thermalexpansion.semicolon=：
 
 info.thermalexpansion.augment.dynamoBoiler.0=발전기: 출력 특징
 info.thermalexpansion.augment.dynamoBoiler.a.0=해당 발전기를 증기 보일러로 변환합니다.

--- a/src/main/resources/assets/thermalexpansion/lang/nl_NL.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/nl_NL.lang
@@ -15,6 +15,8 @@ info.thermalexpansion.dynamo.magmatic=Vereist hete vloeistoffen.
 info.thermalexpansion.dynamo.reactant=Vereist vloeibare brandstof en vaste reagent.
 info.thermalexpansion.dynamo.steam=Vereist water en vaste brandstof.
 
+info.thermalexpansion.semicolon=: 
+
 info.thermalexpansion.machine.charger=Laad items op met RF.
 info.thermalexpansion.machine.crucible=Smelt items tot vloeistoffen.
 info.thermalexpansion.machine.extruder=Mixt hete en koude vloeistoffen.

--- a/src/main/resources/assets/thermalexpansion/lang/pt_BR.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/pt_BR.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=Aumentar a Entrada de RF em
 gui.thermalexpansion.storage.cell.incSend=Aumentar a Saída de RF em
 
 info.thermalexpansion.augment.0=Melhoria
+info.thermalexpansion.semicolon=: 
 
 info.thermalexpansion.augment.dynamoBoiler.0=Dínamos: Especialização de Saída
 info.thermalexpansion.augment.dynamoBoiler.a.0=Converte um dínamo apropriado em uma caldeira a vapor

--- a/src/main/resources/assets/thermalexpansion/lang/ru_RU.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/ru_RU.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=Увеличение входа RF н�
 gui.thermalexpansion.storage.cell.incSend=Увеличение выхода RF на
 
 info.thermalexpansion.augment.0=Расширение
+info.thermalexpansion.semicolon=: 
 
 info.thermalexpansion.augment.dynamoBoiler.0=Генератор: Специализация выхода
 info.thermalexpansion.augment.dynamoBoiler.a.0=Преобразует подходящий генератор в паровой котел.

--- a/src/main/resources/assets/thermalexpansion/lang/zh_CN.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/zh_CN.lang
@@ -41,6 +41,7 @@ gui.thermalexpansion.storage.cell.incRecv=按一下增加RF输入
 gui.thermalexpansion.storage.cell.incSend=按一下增加RF输出
 
 info.thermalexpansion.augment.0=升级
+info.thermalexpansion.semicolon=：
 
 info.thermalexpansion.augment.dynamoBoiler.0=蒸汽能源炉：蒸汽锅炉
 info.thermalexpansion.augment.dynamoBoiler.a.0=将能源炉变成真正的蒸汽锅炉。

--- a/src/main/resources/assets/thermalexpansion/lang/zh_TW.lang
+++ b/src/main/resources/assets/thermalexpansion/lang/zh_TW.lang
@@ -29,6 +29,8 @@ info.thermalexpansion.machine.sawmill=增產木材。
 info.thermalexpansion.machine.smelter=冶煉合金和金屬。兩個輸入。
 info.thermalexpansion.machine.transposer=處理液體與液體容器。
 
+info.thermalexpansion.semicolon=：
+
 item.thermalexpansion.augment.dynamoCoilDuct.name=傳輸線圈管道
 item.thermalexpansion.augment.dynamoThrottle.name=節流閥裝置
 


### PR DESCRIPTION
Replace half-width semicolons `:` with full-width semicolons `：` in CJK languages.