### PR TITLE
Add input overrides for machine specializations

### DIFF
--- a/src/main/java/cofh/thermalexpansion/util/managers/machine/PulverizerManager.java
+++ b/src/main/java/cofh/thermalexpansion/util/managers/machine/PulverizerManager.java
@@ -8,6 +8,7 @@ import cofh.core.util.helpers.StringHelper;
 import cofh.thermalexpansion.ThermalExpansion;
 import cofh.thermalfoundation.init.TFEquipment.ToolSetVanilla;
 import cofh.thermalfoundation.item.ItemMaterial;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -16,10 +17,14 @@ import net.minecraftforge.oredict.OreDictionary;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.annotation.Nullable;
+
 public class PulverizerManager {
 
 	private static Map<ComparableItemStackValidated, PulverizerRecipe> recipeMap = new Object2ObjectOpenHashMap<>();
 	private static OreValidator oreValidator = new OreValidator();
+	
+	private static Map<ComparableItemStack, Boolean> oreOverrideMap = new Object2BooleanOpenHashMap<ComparableItemStack>(); // Unvalidated because less overhead and people would want to add whole OreDict entries outside of ores
 
 	static {
 		oreValidator.addPrefix(ComparableItemStack.ORE);
@@ -233,10 +238,51 @@ public class PulverizerManager {
 	}
 
 	public static boolean isOre(ItemStack stack) {
+		ComparableItemStack query = new ComparableItemStack(stack);
+		if(oreOverrideMap.containsKey(query)) return oreOverrideMap.get(query);
+		query.metadata = OreDictionary.WILDCARD_VALUE;
+		if(oreOverrideMap.containsKey(query)) return oreOverrideMap.get(query);
 
 		return ItemHelper.isOre(stack) || ItemHelper.isCluster(stack);
 	}
 
+	/* ORE OVERRIDES */
+	@Nullable
+	/**
+	 * Adds an override for an {@code ItemStack} to be in the set of ores accepted by the Tectonic Initiator
+	 * @param stack	The {@code ItemStack} to add the override for. Can use {@link OreDictionary.WILDCARD_VALUE wildcard metadata}.
+	 * @param value The override value
+	 * @return The previous value associated with {@code stack}, or {@code null} if there was no mapping for {@code stack}.
+	 * @see Map#put(Object, Object)
+	 */
+	public static Boolean addOreOverride(ItemStack stack, boolean value) {
+		ComparableItemStack query = new ComparableItemStack(stack);
+		return oreOverrideMap.put(query, value);
+	}
+
+	@Nullable
+	/**
+	 * Removes the override for an {@code ItemStack} in the set of ores accepted by the Tectonic Initiator
+	 * @param stack	The {@code ItemStack} to remove the override for. Can use {@link OreDictionary.WILDCARD_VALUE wildcard metadata}.
+	 * @return Whether the remove operation was successful.
+	 * @see Map#remove(Object, Object)
+	 */
+	public static Boolean removeOreOverride(ItemStack stack) {
+		ComparableItemStack query = new ComparableItemStack(stack);
+		return oreOverrideMap.remove(query);
+	}
+
+	/**
+	 * Checks if there is any override for an {@code ItemStack} for the Tectonic Initiator
+	 * @param stack	The {@code ItemStack} to remove the override for. Can use {@link OreDictionary.WILDCARD_VALUE wildcard metadata}.
+	 * @return {@code true} if there is an override for {@code stack}.
+	 * @see Map#containsKey(Object, Object)
+	 */
+	public static boolean hasOreOverride(ItemStack stack) {
+		ComparableItemStack query = new ComparableItemStack(stack);
+		return oreOverrideMap.containsKey(query);
+	}
+	
 	/* RECIPE CLASS */
 	public static class PulverizerRecipe {
 


### PR DESCRIPTION
Currently, there are four specializations that only accept that external mods cannot interact with or add input items to. The most important of these are:
1. The Induction Smelter's *Pyro-Concentrator* specialization.
2. The Pulverizer's *Tectonic Initiator* specialization.
3. The Redstone Furnace's *Trivection Chamber* and *Flux Anodizers* specialization.

This pull request adds methods to add overrides to the helper methods that these specializations rely on to let external code mark items as valid inputs for these specializations.  
Originally, I was going to add a separate recipe map for each of these specializations; however, after considering the popularity and importance that of Thermal Expansion, I concluded that this would be an inappropriate course of action as it would require significant code changes that had the possibility of creating incompatibilities with pre-existing mods. Instead a simple `ComparableItemStack` to `Boolean` map was introduced that overrides the default return value of the related method, as this would not create any incompatibilities (excluding any mods that might use ASM to modify the Thermal Expansion bytecode, of which I know none).

Only four existing codepoints were touched in this request: `FurnaceManager.isFood(stack)`, `FurnaceManager.isOre(stack)`, `PulverizerManager.isOre(stack)` and `SmelterManager.isOre(stack)`. The only other changes are methods being added to interface with the override maps. The mods has been built and tested to ensure that the existing behaviours remain unmodified.

If this pull request is accepted, I will likely immediately create a second pull request for ModTweaker to add support for this new functionality.